### PR TITLE
Fix daily usage warning counts and add test

### DIFF
--- a/src/app/api/cron/daily-usage/route.test.ts
+++ b/src/app/api/cron/daily-usage/route.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+test('GET aggregates warningCount across user telemetry issues', async () => {
+  process.env.CRON_SECRET = 'test-secret';
+  process.env.DATABASE_URL = 'postgresql://user:password@localhost/db';
+
+  const { createDailyUsageHandler } = await import('./route');
+
+  const fakeUsers = [
+    { id: 'user-1' },
+    { id: 'user-2' },
+    { id: 'user-3' },
+  ];
+
+  const telemetryByUser = new Map<string, { issues: Array<{ message: string }> }>([
+    ['user-1', { issues: [{ message: 'issue-a' }] }],
+    ['user-2', { issues: [{ message: 'issue-b' }, { message: 'issue-c' }] }],
+    ['user-3', { issues: [] }],
+  ]);
+
+  const handler = createDailyUsageHandler({
+    fetchAndStoreUsageForUser: async (userId: string) => ({
+      userId,
+      processedKeys: 0,
+      simulatedKeys: 0,
+      failedKeys: 0,
+      storedEvents: 0,
+      skippedEvents: 0,
+      issues: telemetryByUser.get(userId)?.issues ?? [],
+    }),
+    loadDatabase: async () => ({
+      db: {
+        select: () => ({
+          from: async () => fakeUsers,
+        }),
+      },
+      users: { id: 'id' } as any,
+    }),
+  });
+
+  const request = { headers: new Headers({ authorization: 'Bearer test-secret' }) } as any;
+  const response = await handler(request);
+  const payload = await response.json();
+
+  const expectedWarningCount = [...telemetryByUser.values()].reduce(
+    (sum, telemetry) => sum + telemetry.issues.length,
+    0
+  );
+
+  assert.equal(payload.warningCount, expectedWarningCount);
+  assert.deepEqual(
+    (payload.warnings as Array<{ userId: string }>).map((entry) => entry.userId).sort(),
+    ['user-1', 'user-2']
+  );
+});

--- a/src/app/api/cron/daily-usage/route.ts
+++ b/src/app/api/cron/daily-usage/route.ts
@@ -1,62 +1,92 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchAndStoreUsageForUser } from '../../../../lib/usage-fetcher';
 
-export async function GET(request: NextRequest) {
-  try {
-    // Verify this is a legitimate cron request
-    const authHeader = request.headers.get('authorization');
-    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+type DatabaseModule = typeof import('../../../../lib/database');
+type SchemaModule = typeof import('../../../../db/schema');
+
+type DailyUsageDependencies = {
+  fetchAndStoreUsageForUser: typeof fetchAndStoreUsageForUser;
+  loadDatabase: () => Promise<{
+    db: Pick<DatabaseModule['db'], 'select'>;
+    users: SchemaModule['users'];
+  }>;
+};
+
+export function createDailyUsageHandler({
+  fetchAndStoreUsageForUser: fetchUsage,
+  loadDatabase,
+}: DailyUsageDependencies) {
+  return async function GET(request: NextRequest) {
+    try {
+      // Verify this is a legitimate cron request
+      const authHeader = request.headers.get('authorization');
+      if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      console.log('Starting daily usage fetch cron job');
+
+      // Import database dependencies
+      const { db, users } = await loadDatabase();
+
+      // Get all users in the system
+      const allUsers = await db.select({ id: users.id }).from(users);
+
+      console.log(`Found ${allUsers.length} users to process`);
+
+      let successCount = 0;
+      let errorCount = 0;
+      let warningCount = 0;
+      const warnings: Array<{ userId: string; issues: number }> = [];
+
+      // Process each user
+      for (const user of allUsers) {
+        try {
+          const telemetry = await fetchUsage(user.id, 1); // Fetch last 1 day
+          successCount++;
+          if (telemetry.issues.length > 0) {
+            warnings.push({ userId: user.id, issues: telemetry.issues.length });
+            warningCount += telemetry.issues.length;
+            console.warn(
+              `Usage ingestion completed with ${telemetry.issues.length} issues for user ${user.id}`,
+              telemetry
+            );
+          } else {
+            console.log(`Successfully processed user ${user.id}`);
+          }
+        } catch (error) {
+          errorCount++;
+          console.error(`Error processing user ${user.id}:`, error);
+        }
+      }
+
+      const result = {
+        success: true,
+        processed: allUsers.length,
+        successful: successCount,
+        errors: errorCount,
+        warningCount,
+        warnings,
+        timestamp: new Date().toISOString(),
+      };
+
+      console.log('Daily usage fetch completed:', result);
+      return NextResponse.json(result);
+    } catch (error) {
+      console.error('Error in daily usage cron job:', error);
+      return NextResponse.json({
+        error: 'Failed to run daily usage fetch',
+        timestamp: new Date().toISOString()
+      }, { status: 500 });
     }
+  };
+}
 
-    console.log('Starting daily usage fetch cron job');
-
-    // Import database dependencies
+export const GET = createDailyUsageHandler({
+  fetchAndStoreUsageForUser,
+  loadDatabase: async () => {
     const { db } = await import('../../../../lib/database');
     const { users } = await import('../../../../db/schema');
-
-    // Get all users in the system
-    const allUsers = await db.select({ id: users.id }).from(users);
-    
-    console.log(`Found ${allUsers.length} users to process`);
-
-    let successCount = 0;
-    let errorCount = 0;
-    const warnings: Array<{ userId: string; issues: number }> = [];
-
-    // Process each user
-    for (const user of allUsers) {
-      try {
-        const telemetry = await fetchAndStoreUsageForUser(user.id, 1); // Fetch last 1 day
-        successCount++;
-        if (telemetry.issues.length > 0) {
-          warnings.push({ userId: user.id, issues: telemetry.issues.length });
-          console.warn('Usage ingestion completed with issues', telemetry);
-        } else {
-          console.log(`Successfully processed user ${user.id}`);
-        }
-      } catch (error) {
-        errorCount++;
-        console.error(`Error processing user ${user.id}:`, error);
-      }
-    }
-
-    const result = {
-      success: true,
-      processed: allUsers.length,
-      successful: successCount,
-      errors: errorCount,
-      warnings,
-      timestamp: new Date().toISOString(),
-    };
-
-    console.log('Daily usage fetch completed:', result);
-    return NextResponse.json(result);
-  } catch (error) {
-    console.error('Error in daily usage cron job:', error);
-    return NextResponse.json({ 
-      error: 'Failed to run daily usage fetch',
-      timestamp: new Date().toISOString()
-    }, { status: 500 });
-  }
-}
+    return { db, users };
+  },
+});


### PR DESCRIPTION
## Summary
- adjust the daily usage cron handler to sum the number of telemetry issues per user and expose a factory for dependency injection
- add a node:test that exercises the handler with mocked dependencies to confirm warningCount matches the aggregated issue total

## Testing
- npx tsx --test src/app/api/cron/daily-usage/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc2e655ee0832bb8e9e0af0d35db91