### PR TITLE
Improve analytics contrast and token usage

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,7 +29,7 @@
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 74% 42%;
     --destructive-foreground: 210 40% 98%;
 
     --ring: 221.2 83.2% 53.3%;

--- a/src/components/CostAlerts.tsx
+++ b/src/components/CostAlerts.tsx
@@ -34,16 +34,16 @@ const STATUS_STYLES: Record<'safe' | 'warning' | 'danger', { badge: string; bord
     text: 'text-muted-foreground'
   },
   warning: {
-    badge: 'bg-amber-100 text-amber-900',
-    border: 'border-amber-200 bg-amber-50',
-    bar: 'bg-amber-500',
-    text: 'text-amber-800'
+    badge: 'bg-secondary text-secondary-foreground',
+    border: 'border-primary/40 bg-secondary',
+    bar: 'bg-secondary-foreground',
+    text: 'text-foreground'
   },
   danger: {
-    badge: 'bg-destructive/20 text-destructive',
-    border: 'border-destructive/40 bg-destructive/10',
+    badge: 'bg-destructive text-destructive-foreground',
+    border: 'border-destructive bg-destructive/15',
     bar: 'bg-destructive',
-    text: 'text-destructive'
+    text: 'text-foreground'
   }
 };
 
@@ -180,7 +180,7 @@ export default function CostAlerts({ events, className }: CostAlertsProps) {
       </div>
 
       {activeAlerts.length > 0 && (
-        <div className="border-b border-border bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        <div className="border-b border-destructive bg-destructive/15 px-4 py-3 text-sm text-foreground">
           <h3 className="font-medium">Active alerts</h3>
           <div className="mt-2 space-y-2">
             {activeAlerts.map(({ threshold, usage, alert }) => (

--- a/src/components/DataAggregation.tsx
+++ b/src/components/DataAggregation.tsx
@@ -169,8 +169,8 @@ export default function DataAggregation({ events, className }: DataAggregationPr
                   ]}
                 />
                 <Bar dataKey="requests" fill="hsl(var(--primary))" name="Requests" radius={[6, 6, 0, 0]} />
-                <Bar dataKey="tokens" fill="hsl(var(--accent))" name="Tokens" radius={[6, 6, 0, 0]} />
-                <Bar dataKey="cost" fill="hsl(var(--secondary))" name="Cost ($)" radius={[6, 6, 0, 0]} />
+                <Bar dataKey="tokens" fill="hsl(var(--muted-foreground))" name="Tokens" radius={[6, 6, 0, 0]} />
+                <Bar dataKey="cost" fill="hsl(var(--secondary-foreground))" name="Cost ($)" radius={[6, 6, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/components/ExportControls.tsx
+++ b/src/components/ExportControls.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from 'react';
 import { exportUsageToCSV, exportUsageSummaryToCSV } from '../lib/csv-export';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 interface UsageEvent {
   id: number;
@@ -48,31 +50,32 @@ export default function ExportControls({ events, className }: ExportControlsProp
   };
 
   return (
-    <div className={`flex flex-col sm:flex-row gap-3 ${className || ''}`}>
-      <button
+    <div className={cn('flex flex-col gap-3 sm:flex-row', className)}>
+      <Button
         onClick={handleExportRawData}
         disabled={isExporting || events.length === 0}
-        className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        className="justify-center"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
         {isExporting ? 'Exporting...' : 'Export Raw Data'}
-      </button>
-      
-      <button
+      </Button>
+
+      <Button
+        variant="secondary"
         onClick={handleExportSummary}
         disabled={isExporting || events.length === 0}
-        className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        className="justify-center"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
         {isExporting ? 'Exporting...' : 'Export Summary'}
-      </button>
-      
+      </Button>
+
       {events.length === 0 && (
-        <p className="text-sm text-gray-500 self-center">
+        <p className="self-center text-sm text-muted-foreground">
           No data available for export
         </p>
       )}

--- a/src/components/GrowthAnalysis.tsx
+++ b/src/components/GrowthAnalysis.tsx
@@ -21,8 +21,8 @@ interface GrowthAnalysisProps {
 }
 
 const GROWTH_STYLES = {
-  positive: { chip: 'bg-emerald-100 text-emerald-900', text: 'text-emerald-600' },
-  negative: { chip: 'bg-rose-100 text-rose-900', text: 'text-rose-600' },
+  positive: { chip: 'bg-primary text-primary-foreground', text: 'text-foreground' },
+  negative: { chip: 'bg-destructive text-destructive-foreground', text: 'text-foreground' },
   neutral: { chip: 'bg-muted text-muted-foreground', text: 'text-muted-foreground' }
 };
 

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
 
 interface RefreshButtonProps {
   onRefresh?: () => Promise<any>;
@@ -50,10 +52,10 @@ export default function RefreshButton({ onRefresh, children, className }: Refres
   };
 
   return (
-    <button 
+    <button
       onClick={handleClick}
       disabled={isLoading}
-      className={className || "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"}
+      className={cn(buttonVariants(), className)}
     >
       {isLoading ? 'Loading...' : children}
     </button>

--- a/src/components/UsageChart.tsx
+++ b/src/components/UsageChart.tsx
@@ -34,7 +34,7 @@ export default function UsageChart({ data, type }: UsageChartProps) {
     return value.toString();
   };
 
-  const strokeColor = type === 'tokens' ? 'hsl(var(--primary))' : 'hsl(var(--accent))';
+  const strokeColor = type === 'tokens' ? 'hsl(var(--primary))' : 'hsl(var(--muted-foreground))';
 
   return (
     <div className="h-80 rounded-lg border border-border bg-card p-6 shadow-sm">


### PR DESCRIPTION
## Summary
- darken the light theme destructive token to meet AA with shared foreground text
- remap cost alerts, export controls, growth deltas, charts, and refresh button to tokenized colors with readable contrast
- refresh analytics visuals by assigning neutral foreground fills and lines instead of near-white accent tones

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/drizzle-kit)*

------
https://chatgpt.com/codex/tasks/task_e_68dd34f04c40832b97562727197735fe